### PR TITLE
feat: add Flatpak release workflow for GitHub Releases

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  release:
+    types:
+        - prereleased
+        # - published
+
+jobs:
+  flatpak:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            flatpak \
+            flatpak-builder
+
+      - name: Setup
+        run: |
+          flatpak --version
+          flatpak remote-add \
+            --if-not-exists flathub \
+            https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build
+        run: |
+          flatpak-builder \
+            --force-clean \
+            --install-deps-from=flathub \
+            --repo=repo builddir \
+            io.github.ruffsl.ctrlassist.yml
+
+      - name: Bundle
+        run: |
+          flatpak build-bundle \
+            repo ctrlassist.flatpak \
+            io.github.ruffsl.ctrlassist stable
+
+      - name: Upload
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ctrlassist.flatpak
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the Flatpak release process. The workflow is triggered on prerelease events and handles building, bundling, and uploading the Flatpak package.